### PR TITLE
added config to docker-compose.override.yml to set force_ssl in Rails production environment

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,3 +21,5 @@ services:
   web:
     ports:
       - 3000:3000
+    environment:
+    - RAILS_FORCE_SSL=false

--- a/hyrax/config/environments/production.rb
+++ b/hyrax/config/environments/production.rb
@@ -55,7 +55,11 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  if ENV["RAILS_FORCE_SSL"].present? && (ENV["RAILS_FORCE_SSL"].to_s.downcase == 'false') then
+    config.force_ssl = false
+  else
+    config.force_ssl = true #default if nothing specified is more secure.
+  end
 
   # Use the lowest log level (:debug) to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Although we use 'production' and 'development' environments from the pint of view of Docker, we always use the Rails `production` environment. This had the side effect of setting `force_ssl` to true, even in a 'development' context.

This PR adds an ENV variable to `docker-compose.override.yml` to set`RAILS_FORCE_SSL` to false, and configures the Rails `production.rb` environment file  to look for this new ENV variable.