### PR TITLE
Delete resourcesync link tag

### DIFF
--- a/hyrax/app/views/layouts/_head_tag_content.html.erb
+++ b/hyrax/app/views/layouts/_head_tag_content.html.erb
@@ -8,7 +8,6 @@ signed in %>
 <% end %>
 <!-- added for use on small devices like phones -->
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link rel="resourcesync" href="<%= hyrax.capability_list_url %>" />
 
 <!-- Twitter card metadata -->
 <%= yield :twitter_meta %>


### PR DESCRIPTION
#409 did not remove the link tag in HTML's head.

Closes https://github.com/antleaf/nims-mdr-development/issues/476